### PR TITLE
Fix resource cleanup and naming

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,9 @@ text = Test prompt`
 	t.Run("LoadConfigFromFile", func(t *testing.T) {
 		// Удаляем переменную окружения, если она существует
 		if runtime.GOOS != "windows" {
-			os.Unsetenv("TEST_API_KEY")
+			if err := os.Unsetenv("TEST_API_KEY"); err != nil {
+				t.Fatalf("failed to unset env: %v", err)
+			}
 		}
 
 		config, err := loadConfig(configPath)
@@ -77,8 +79,14 @@ text = Test prompt`
 
 	// Тест с использованием API ключа из переменной окружения
 	t.Run("LoadConfigFromEnv", func(t *testing.T) {
-		os.Setenv("TEST_API_KEY", "env_test_key")
-		defer os.Unsetenv("TEST_API_KEY")
+		if err := os.Setenv("TEST_API_KEY", "env_test_key"); err != nil {
+			t.Fatalf("failed to set env: %v", err)
+		}
+		defer func() {
+			if err := os.Unsetenv("TEST_API_KEY"); err != nil {
+				t.Fatalf("failed to unset env: %v", err)
+			}
+		}()
 
 		config, err := loadConfig(configPath)
 		if err != nil {


### PR DESCRIPTION
## Summary
- handle errors when closing files and responses
- rename rate limiter fields for clarity
- check env var operations in tests

## Testing
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f3bde9dd4832088b13967c83d05fb